### PR TITLE
Improve installation scripts and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,19 @@ Top Board control program
 [Penta SATA HAT docs](https://docs.radxa.com/en/accessories/penta-sata-hat)
 
 ![penta-hat](images/penta-sata-hat.png)
+
+## Installation
+
+Run the provided `install.sh` script on the target system. It installs
+`python3-venv`, `smartmontools` and other prerequisites, sets up the
+Python environment and enables the service:
+
+```bash
+sudo ./rockpi-penta/install.sh
+```
+
+After installation, monitor the daemon with:
+
+```bash
+sudo journalctl -u rockpi-penta -f
+```

--- a/rockpi-penta/debian/postinst
+++ b/rockpi-penta/debian/postinst
@@ -31,11 +31,19 @@ fi
 #    but sync in case /boot is on SD
 sync
 
+# 5. set up the Python virtual environment
+if [ ! -d /opt/rockpi-penta-venv ]; then
+    python3 -m venv /opt/rockpi-penta-venv
+fi
+/opt/rockpi-penta-venv/bin/pip install -U pip
+/opt/rockpi-penta-venv/bin/pip install /usr/src/rockpi-penta
+
 
 case "$1" in
   configure|upgrade)
     systemctl daemon-reload
     systemctl enable --now rockpi-penta.service
+    echo "rockpi-penta installed. View logs with: sudo journalctl -u rockpi-penta -f"
     ;;
 esac
 

--- a/rockpi-penta/install.sh
+++ b/rockpi-penta/install.sh
@@ -1,14 +1,23 @@
 #!/usr/bin/env bash
 set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DEST=/usr/src/rockpi-penta
+
 echo "[1/3] apt packages…"
 sudo apt update
 sudo apt install -y python3 python3-venv smartmontools gpiod
-echo "[2/3] venv…"
+
+echo "[2/3] venv & sources…"
+sudo mkdir -p "$DEST"
+sudo cp -rT "$SCRIPT_DIR" "$DEST"
 sudo python3 -m venv /opt/rockpi-penta-venv
 sudo /opt/rockpi-penta-venv/bin/pip install -U pip
-sudo /opt/rockpi-penta-venv/bin/pip install /usr/src/rockpi-penta   # adjust path
+sudo /opt/rockpi-penta-venv/bin/pip install "$DEST"
+
 echo "[3/3] systemd…"
-sudo install -Dm644 systemd/rockpi-penta.service /etc/systemd/system/rockpi-penta.service
+sudo install -Dm644 "$DEST/systemd/rockpi-penta.service" /etc/systemd/system/rockpi-penta.service
 sudo systemctl daemon-reload
 sudo systemctl enable --now rockpi-penta.service
+
 echo "✓ done  (logs: sudo journalctl -u rockpi-penta -f)"


### PR DESCRIPTION
## Summary
- document install method in README
- copy sources and create venv in `install.sh`
- set up venv during `postinst` and print log hint

## Testing
- `python3 -m py_compile rockpi-penta/fan.py rockpi-penta/misc.py rockpi-penta/main.py`

------
https://chatgpt.com/codex/tasks/task_e_688d129dfdc88321b73969a61c1998de