### PR TITLE
Fix missing pyproject in deb

### DIFF
--- a/rockpi-penta/debian/changelog
+++ b/rockpi-penta/debian/changelog
@@ -1,3 +1,9 @@
+rockpi-penta (1.0.3-2) unstable; urgency=medium
+
+  * Include pyproject.toml so postinst can pip install
+
+ -- RYZEN7 <mika@RYZEN7.localdomain>  Fri, 01 Aug 2025 20:37:09 +0000
+
 rockpi-penta (1.0.3-1) unstable; urgency=medium
 
   * Initial release: Rock 5 C hwmon-only fan controller

--- a/rockpi-penta/debian/install
+++ b/rockpi-penta/debian/install
@@ -5,3 +5,4 @@ install.sh                                                 usr/src/doc/rockpi-pe
 lib/systemd/system/rockpi-penta.service        lib/systemd/system/
 etc/rockpi-penta.conf               etc/
 rk3588-pwm14-fan.dtbo               usr/src/rockpi-penta/
+pyproject.toml                      usr/src/rockpi-penta/


### PR DESCRIPTION
## Summary
- install pyproject.toml into /usr/src/rockpi-penta
- update changelog for 1.0.3-2

## Testing
- `python3 -m py_compile rockpi-penta/*.py`

------
https://chatgpt.com/codex/tasks/task_e_688d2515c80883218d0ac663cf7fbd11