### PR TITLE
Fix Python package discovery

### DIFF
--- a/rockpi-penta/pyproject.toml
+++ b/rockpi-penta/pyproject.toml
@@ -7,3 +7,6 @@ name = "rockpi-penta"
 version = "1.0.3"
 description = "Rock 5 C hwmon fan controller"
 dependencies = []
+
+[tool.setuptools]
+py-modules = ["main", "fan", "misc"]


### PR DESCRIPTION
## Summary
- fix pyproject to explicitly list modules for setuptools

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688d268775ec83218c13e6de301a8b38