### PR TITLE
Fix inline comments parsing in config

### DIFF
--- a/rockpi-penta/misc.py
+++ b/rockpi-penta/misc.py
@@ -40,7 +40,7 @@ _DEFAULTS = {
 # ────────── load / reload config  ───────────────────────────
 def read_conf() -> dict:
     """Parse /etc/rockpi-penta.conf, return nested dict with fallbacks."""
-    cfg = ConfigParser()
+    cfg = ConfigParser(inline_comment_prefixes=("#", ";"))
     cfg.read_dict(_DEFAULTS)                  # preload defaults
     try:
         cfg.read("/etc/rockpi-penta.conf")


### PR DESCRIPTION
## Summary
- allow inline comments for rockpi-penta.conf by enabling `inline_comment_prefixes`

## Testing
- `python3 -m py_compile rockpi-penta/*.py`
- `PYTHONPATH=rockpi-penta python3 - <<'EOF'
import misc
print(misc.read_conf())
EOF`

------
https://chatgpt.com/codex/tasks/task_e_688d27c525d083219726c48a75e40425