### PR TITLE
Use armbian-add-overlay for device-tree overlays

### DIFF
--- a/rockpi-penta/debian/postinst
+++ b/rockpi-penta/debian/postinst
@@ -2,41 +2,28 @@
 set -e
 
 DTB_SRC="/usr/src/rockpi-penta/rk3588-pwm14-fan.dtbo"
-DTB_DST="/boot/dtb/rockchip/overlay/rk3588-pwm14-fan.dtbo"
-
 DTB2_SRC="/usr/src/rockpi-penta/rk3588-pwm-fan.dtbo"
-DTB2_DST="/boot/dtb/rockchip/overlay/rk3588-pwm-fan.dtbo"
-
+BUILTIN="/boot/dtb/rockchip/overlay/rk3588-pwm14-m1.dtbo"
 ARM_ENV="/boot/armbianEnv.txt"
 
-# 1. install the overlay (create dir if missing)
-install -Dm644 "$DTB_SRC" "$DTB_DST"
-install -Dm644 "$DTB2_SRC" "$DTB2_DST"
+# 1. install overlays using armbian-add-overlay
+armbian-add-overlay "$DTB_SRC"
+armbian-add-overlay "$DTB2_SRC"
+[ -f "$BUILTIN" ] && armbian-add-overlay "$BUILTIN"
 
-# 2. ensure overlay_prefix=rk3588  (replace or append)
-# if grep -q "^overlay_prefix=" "$ARM_ENV"; then
-#     sed -i 's/^overlay_prefix=.*/overlay_prefix=rk3588/' "$ARM_ENV"
-# else
-#     echo "overlay_prefix=rk3588" >>"$ARM_ENV"
-# fi
-
-# 3. ensure overlays line contains exactly pwm-fan pwm14-fan pwm14-m1
-#    (order preserved, duplicates removed)
-if grep -q "^overlays=" "$ARM_ENV"; then
-    # strip any existing pwm-fan / pwm14-fan / pwm14-m1 first, then append fresh list
-    current=$(grep "^overlays=" "$ARM_ENV" | cut -d= -f2-)
-    # remove duplicates of our two overlays
+# 2. ensure user_overlays line contains pwm-fan pwm14-fan pwm14-m1
+if grep -q "^user_overlays=" "$ARM_ENV"; then
+    current=$(grep "^user_overlays=" "$ARM_ENV" | cut -d= -f2-)
     clean=$(echo "$current" | tr ' ' '\n' | grep -vE '^(pwm-fan|pwm14-fan|pwm14-m1)$' | xargs)
-    sed -i "s/^overlays=.*/overlays=$clean pwm-fan pwm14-fan pwm14-m1/" "$ARM_ENV"
+    sed -i "s/^user_overlays=.*/user_overlays=$clean pwm-fan pwm14-fan pwm14-m1/" "$ARM_ENV"
 else
-    echo "overlays=pwm-fan pwm14-fan pwm14-m1" >>"$ARM_ENV"
+    echo "user_overlays=pwm-fan pwm14-fan pwm14-m1" >>"$ARM_ENV"
 fi
 
-# 4. mkinitcpio / update-initramfs is not needed for runtime overlays,
-#    but sync in case /boot is on SD
+# 3. sync in case /boot is on SD
 sync
 
-# 5. set up the Python virtual environment
+# 4. set up the Python virtual environment
 if [ ! -d /opt/rockpi-penta-venv ]; then
     python3 -m venv /opt/rockpi-penta-venv
 fi

--- a/rockpi-penta/debian/postrm
+++ b/rockpi-penta/debian/postrm
@@ -1,29 +1,22 @@
 #!/bin/sh
 set -e
 
-DTB="/boot/dtb/rockchip/overlay/rk3588-pwm14-fan.dtbo"
-DTB2="/boot/dtb/rockchip/overlay/rk3588-pwm-fan.dtbo"
 ENV="/boot/armbianEnv.txt"
 
 case "$1" in
     remove|purge)
-        # 1) delete the overlay file if we installed it
-        [ -f "$DTB" ] && rm -f "$DTB"
-        [ -f "$DTB2" ] && rm -f "$DTB2"
+        # 1) delete installed overlay files
+        for dir in /boot/overlay-user /boot/dtb/rockchip/overlay-user /boot/dtb/rockchip/overlay; do
+            [ -f "$dir/rk3588-pwm14-fan.dtbo" ] && rm -f "$dir/rk3588-pwm14-fan.dtbo"
+            [ -f "$dir/rk3588-pwm-fan.dtbo" ] && rm -f "$dir/rk3588-pwm-fan.dtbo"
+            [ -f "$dir/rk3588-pwm14-m1.dtbo" ] && rm -f "$dir/rk3588-pwm14-m1.dtbo"
+        done
 
-        # 2) strip pwm14-fan and pwm14-m1 from overlays= line
-        if [ -f "$ENV" ] && grep -q "^overlays=" "$ENV"; then
-            # remove both tokens; collapse multiple spaces
+        # 2) strip overlays from user_overlays line
+        if [ -f "$ENV" ] && grep -q "^user_overlays=" "$ENV"; then
             sed -i 's/\s*pwm-fan\s*//g; s/\s*pwm14-fan\s*//g; s/\s*pwm14-m1\s*//g; s/  */ /g' "$ENV"
-            # if overlays line became empty, remove the line entirely
-            sed -i '/^overlays=\s*$/d' "$ENV"
+            sed -i '/^user_overlays=\s*$/d' "$ENV"
         fi
-
-        # (optional) restore overlay_prefix only if we set it
-        # if [ "$1" = purge ]; then
-        #     # Example: revert to rockchip if user purges
-        #     sed -i 's/^overlay_prefix=rk3588/overlay_prefix=rockchip/' "$ENV" || true
-        # fi
         ;;
 esac
 

--- a/rockpi-penta/install.sh
+++ b/rockpi-penta/install.sh
@@ -4,18 +4,34 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 DEST=/usr/src/rockpi-penta
 
-echo "[1/3] apt packages…"
+echo "[1/4] apt packages…"
 sudo apt update
 sudo apt install -y python3 python3-venv smartmontools gpiod
 
-echo "[2/3] venv & sources…"
+echo "[2/4] device-tree overlays…"
+sudo armbian-add-overlay "$SCRIPT_DIR/rk3588-pwm-fan.dtbo"
+sudo armbian-add-overlay "$SCRIPT_DIR/rk3588-pwm14-fan.dtbo"
+if [ -f /boot/dtb/rockchip/overlay/rk3588-pwm14-m1.dtbo ]; then
+    sudo armbian-add-overlay /boot/dtb/rockchip/overlay/rk3588-pwm14-m1.dtbo
+fi
+ARM_ENV=/boot/armbianEnv.txt
+if grep -q "^user_overlays=" "$ARM_ENV"; then
+    current=$(grep "^user_overlays=" "$ARM_ENV" | cut -d= -f2-)
+    clean=$(echo "$current" | tr ' ' '\n' | grep -vE '^(pwm-fan|pwm14-fan|pwm14-m1)$' | xargs)
+    sudo sed -i "s/^user_overlays=.*/user_overlays=$clean pwm-fan pwm14-fan pwm14-m1/" "$ARM_ENV"
+else
+    echo "user_overlays=pwm-fan pwm14-fan pwm14-m1" | sudo tee -a "$ARM_ENV"
+fi
+sudo sync
+
+echo "[3/4] venv & sources…"
 sudo mkdir -p "$DEST"
 sudo cp -rT "$SCRIPT_DIR" "$DEST"
 sudo python3 -m venv /opt/rockpi-penta-venv
 sudo /opt/rockpi-penta-venv/bin/pip install -U pip
 sudo /opt/rockpi-penta-venv/bin/pip install "$DEST"
 
-echo "[3/3] systemd…"
+echo "[4/4] systemd…"
 sudo install -Dm644 "$DEST/systemd/rockpi-penta.service" /etc/systemd/system/rockpi-penta.service
 sudo systemctl daemon-reload
 sudo systemctl enable --now rockpi-penta.service


### PR DESCRIPTION
## Summary
- manage device-tree overlays via `armbian-add-overlay`
- switch overlay configuration to `user_overlays`
- clean up overlays and env vars on removal

## Testing
- `bash -n rockpi-penta/install.sh`
- `bash -n rockpi-penta/debian/postinst`
- `bash -n rockpi-penta/debian/postrm`


------
https://chatgpt.com/codex/tasks/task_e_688e3e24413483218e99fbc4b562fc00