### PR TITLE
Separate CPU fan control using pwm_fan_cpu

### DIFF
--- a/rockpi-penta/etc/rockpi-penta.conf
+++ b/rockpi-penta/etc/rockpi-penta.conf
@@ -1,4 +1,5 @@
-[fan]
+[hat_fan]
+; Drive/HAT fan settings (based on drive temperatures)
 ; °C at which the linear ramp starts / ends
 lv0 = 38          ; fan off-to-slow threshold
 lv1 = 42
@@ -10,9 +11,15 @@ dc_min = 0.001    ; duty-cycle when “off” (0 = stop, 1 = full)
 ; Optional: set this if auto-detection fails
 ;hwmon_path = /sys/class/hwmon/hwmon7
 
-[temperature]
-; Which sensor(s) drive the fan logic:
-;   cpu     – only SoC temperature
-;   drives  – max temp of all HDD/SSD in the HAT
-;   both    – higher of CPU and drives
-source = drives
+[cpu_fan]
+; CPU fan settings (based on SoC temperature)
+lv0 = 38
+lv1 = 42
+lv2 = 46
+lv3 = 50
+hysteresis = 2
+average_samples = 5
+dc_min = 0.001
+; Optional: set this if auto-detection fails
+;hwmon_path = /sys/class/hwmon/hwmon8
+

--- a/rockpi-penta/fan.py
+++ b/rockpi-penta/fan.py
@@ -4,7 +4,7 @@ Rock 5 C – Penta SATA HAT fan controller (kernel pwm-fan only).
 No OLED, no button, no GPIO fallback.
 """
 
-import os, time, subprocess, logging, sys, re
+import time, subprocess, logging, sys, re
 from pathlib import Path
 import misc                    # re-use existing misc.read_conf, fan_temp2dc
 
@@ -16,28 +16,27 @@ logging.basicConfig(
 )
 
 # ────────── locate /sys/class/hwmon/.../pwm1 ─────────────────────
-def find_hat_hwmon(label: str = "pwm-fan-hat") -> Path:
-    """Return ``Path('/sys/class/hwmon/hwmonX')`` for the HAT fan.
+def find_hwmon(label: str) -> Path:
+    """Return ``Path('/sys/class/hwmon/hwmonX')`` for a pwm-fan device.
 
     Older kernels sometimes lack the ``device/of_node`` symlink used to
     identify the overlay device.  In that case, fall back to matching the
-    device directory name which typically contains ``node_name``.
+    device directory name which typically contains ``label``.
     """
-    for d in Path("/sys/class/hwmon").glob("hwmon*"):        
-        target = d.resolve()         
+    for d in Path("/sys/class/hwmon").glob("hwmon*"):
+        target = d.resolve()
         if label in str(target):
             return d
     raise RuntimeError(f"hwmon entry with name '{label}' not found")
 
 class HwmonFan:
-    """Wrapper around the pwm-fan device created by the overlay."""
+    """Wrapper around a pwm-fan device created by a device tree overlay."""
 
-    def __init__(self, node_name: str = "pwm-fan-hat"):
-        path = conf["fan"].get("hwmon_path")
-        if path:
-            hat = Path(path)
+    def __init__(self, node_name: str = "pwm-fan-hat", hwmon_path: str = ""):
+        if hwmon_path:
+            hat = Path(hwmon_path)
         else:
-            hat = find_hat_hwmon(node_name)
+            hat = find_hwmon(node_name)
         self.pwm = hat / "pwm1"
         self.en = hat / "pwm1_enable"
         if self.en.exists():
@@ -51,6 +50,7 @@ class HwmonFan:
 # ────────── temperature helpers ──────────────────────────────────
 _CACHE = {"drives": [], "time": 0}
 conf   = misc.read_conf()
+
 
 def cpu_temp() -> float:
     with open("/sys/class/thermal/thermal_zone0/temp") as f:
@@ -79,27 +79,33 @@ def drive_temps() -> list[float]:
     _CACHE.update(time=time.time(), drives=temps)
     return temps
 
-def effective_temp() -> float:
-    src = conf["temperature"]["source"]
-    cpu = cpu_temp()
-    drv = drive_temps()
-    if src == "cpu":
-        return cpu
-    if src == "drives":
-        return max(drv) if drv else cpu
-    return max([cpu] + drv) if drv else cpu
-
 # ────────── main loop ────────────────────────────────────────────
-fan = HwmonFan()
-logging.info("temperature source = %s", conf["temperature"]["source"])
-logging.info("hwmon path = %s", fan.pwm.parent)
+hat_fan = HwmonFan("pwm-fan-hat", conf["hat_fan"].get("hwmon_path"))
+cpu_fan = HwmonFan("pwm-fan-cpu", conf["cpu_fan"].get("hwmon_path"))
+logging.info("hat fan hwmon path = %s", hat_fan.pwm.parent)
+logging.info("cpu fan hwmon path = %s", cpu_fan.pwm.parent)
 
-_prev = None
+_prev_hat = None
+_prev_cpu = None
+_state_hat: dict = {}
+_state_cpu: dict = {}
+
 while True:
-    temp = effective_temp()
-    dc   = misc.fan_temp2dc(temp)
-    if dc != _prev:
-        fan.write(dc)
-        _prev = dc
-        logging.info("temp=%.1f °C  fan=%.0f %%", temp, dc*100)
+    # CPU fan control
+    t_cpu = cpu_temp()
+    dc_cpu = misc.fan_temp2dc(t_cpu, conf["cpu_fan"], _state_cpu)
+    if dc_cpu != _prev_cpu:
+        cpu_fan.write(dc_cpu)
+        _prev_cpu = dc_cpu
+        logging.info("cpu temp=%.1f °C  cpu fan=%.0f %%", t_cpu, dc_cpu * 100)
+
+    # Drive fan control
+    drv = drive_temps()
+    t_drv = max(drv) if drv else 0
+    dc_hat = misc.fan_temp2dc(t_drv, conf["hat_fan"], _state_hat)
+    if dc_hat != _prev_hat:
+        hat_fan.write(dc_hat)
+        _prev_hat = dc_hat
+        logging.info("drive temp=%.1f °C  hat fan=%.0f %%", t_drv, dc_hat * 100)
+
     time.sleep(1)


### PR DESCRIPTION
## Summary
- drive (HAT) fan now reacts only to drive temperatures
- added independent CPU fan handling driven by `pwm_fan_cpu`
- allow `fan_temp2dc` to track state per fan for accurate hysteresis
- per-fan configuration sections in `rockpi-penta.conf`

## Testing
- `python -m py_compile rockpi-penta/fan.py rockpi-penta/misc.py`


------
https://chatgpt.com/codex/tasks/task_e_688e8087f58883219dea93b9c6d02530