### PR TITLE
Align overlay scripts with armbian configuration

### DIFF
--- a/rockpi-penta/debian/postrm
+++ b/rockpi-penta/debian/postrm
@@ -7,14 +7,23 @@ case "$1" in
     remove|purge)
         # 1) delete installed overlay files
         for dir in /boot/overlay-user /boot/dtb/rockchip/overlay-user /boot/dtb/rockchip/overlay; do
-            [ -f "$dir/rk3588-pwm14-fan.dtbo" ] && rm -f "$dir/rk3588-pwm14-fan.dtbo"
-            [ -f "$dir/rk3588-pwm14-m1.dtbo" ] && rm -f "$dir/rk3588-pwm14-m1.dtbo"
+            rm -f "$dir/rk3588-pwm3-fan.dtbo" \
+                  "$dir/rk3588-pwm14-fan.dtbo" \
+                  "$dir/rk3588-pwm14-m1.dtbo"
         done
 
-        # 2) strip overlays from user_overlays line
-        if [ -f "$ENV" ] && grep -q "^user_overlays=" "$ENV"; then
-            sed -i 's/\s*pwm-fan\s*//g; s/\s*pwm14-fan\s*//g; s/\s*pwm14-m1\s*//g; s/  */ /g' "$ENV"
-            sed -i '/^user_overlays=\s*$/d' "$ENV"
+        # 2) strip overlays from armbianEnv.txt
+        if [ -f "$ENV" ]; then
+            # remove user overlays
+            if grep -q "^user_overlays=" "$ENV"; then
+                sed -i 's/\<rk3588-pwm3-fan\>//g; s/\<rk3588-pwm14-fan\>//g; s/  */ /g' "$ENV"
+                sed -i '/^user_overlays=\s*$/d' "$ENV"
+            fi
+            # remove overlays entries
+            if grep -q "^overlays=" "$ENV"; then
+                sed -i 's/\<pwm14-m1\>//g; s/  */ /g' "$ENV"
+                sed -i '/^overlays=\s*$/d' "$ENV"
+            fi
         fi
         ;;
 esac

--- a/rockpi-penta/install.sh
+++ b/rockpi-penta/install.sh
@@ -9,25 +9,30 @@ sudo apt update
 sudo apt install -y python3 python3-venv smartmontools gpiod
 
 echo "[2/4] device-tree overlays…"
-sudo armbian-add-overlay "$SCRIPT_DIR/rk3588-pwm-fan.dtbo"
-sudo armbian-add-overlay "$SCRIPT_DIR/rk3588-pwm14-fan.dtbo"
+sudo armbian-add-overlay "$SCRIPT_DIR/rk3588-pwm3-fan.dts"
+sudo armbian-add-overlay "$SCRIPT_DIR/rk3588-pwm14-fan.dts"
 if [ -f /boot/dtb/rockchip/overlay/rk3588-pwm14-m1.dtbo ]; then
     sudo armbian-add-overlay /boot/dtb/rockchip/overlay/rk3588-pwm14-m1.dtbo
 fi
 ARM_ENV=/boot/armbianEnv.txt
+if grep -q "^overlay_prefix=" "$ARM_ENV"; then
+    sudo sed -i 's/^overlay_prefix=.*/overlay_prefix=rk3588/' "$ARM_ENV"
+else
+    echo "overlay_prefix=rk3588" | sudo tee -a "$ARM_ENV" >/dev/null
+fi
 if grep -q "^user_overlays=" "$ARM_ENV"; then
     current=$(grep "^user_overlays=" "$ARM_ENV" | cut -d= -f2-)
-    clean=$(echo "$current" | tr ' ' '\n' | grep -vE '^(rk3588-pwm-fan|rk3588-pwm14-fan)$' | xargs)
-    sed -i "s/^user_overlays=.*/user_overlays=$clean rk3588-pwm-fan rk3588-pwm14-fan /" "$ARM_ENV"
+    clean=$(echo "$current" | tr ' ' '\n' | grep -vE '^(rk3588-pwm3-fan|rk3588-pwm14-fan)$' | xargs)
+    sudo sed -i "s/^user_overlays=.*/user_overlays=$clean rk3588-pwm3-fan rk3588-pwm14-fan /" "$ARM_ENV"
 else
-    echo "user_overlays=rk3588-pwm-fan rk3588-pwm14-fan" >>"$ARM_ENV"
+    echo "user_overlays=rk3588-pwm3-fan rk3588-pwm14-fan" | sudo tee -a "$ARM_ENV" >/dev/null
 fi
 if grep -q "^overlays=" "$ARM_ENV"; then
     current=$(grep "^overlays=" "$ARM_ENV" | cut -d= -f2-)
     clean=$(echo "$current" | tr ' ' '\n' | grep -vE '^(pwm14-m1)$' | xargs)
-    sed -i "s/^overlays=.*/overlays=$clean pwm14-m1/" "$ARM_ENV"
+    sudo sed -i "s/^overlays=.*/overlays=$clean pwm14-m1/" "$ARM_ENV"
 else
-    echo "overlays=pwm14-m1" >>"$ARM_ENV"
+    echo "overlays=pwm14-m1" | sudo tee -a "$ARM_ENV" >/dev/null
 fi
 sudo sync
 


### PR DESCRIPTION
## Summary
- use .dts overlay sources and handle overlay prefix in install script
- clean up installed overlay files and config entries in postrm

## Testing
- `bash -n rockpi-penta/install.sh`
- `bash -n rockpi-penta/debian/postrm`
- `python -m py_compile rockpi-penta/*.py`


------
https://chatgpt.com/codex/tasks/task_e_688e852fd9808321b1b93c0da29370dd